### PR TITLE
refactor(actions/): implement "forgot password" backend call

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "start": "webpack-dev-server --mode development",
     "build": "react-scripts build",
     "test": "react-scripts test --env=jsdom",
-    "lint": "./node_modules/.bin/eslint src/**/*.js*",
+    "lint": "eslint src/**/*.js*",
     "eject": "react-scripts eject"
   },
   "devDependencies": {
@@ -44,7 +44,7 @@
     "babel-preset-airbnb": "^4.0.1",
     "css-loader": "^1.0.0",
     "cz-conventional-changelog": "^2.1.0",
-    "eslint": "^6.3.0",
+    "eslint": "^6.5.1",
     "style-loader": "^0.23.1",
     "webpack": "4.39.1",
     "webpack-cli": "3.1.2"

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -1,128 +1,128 @@
-import axios from "axios";
-import * as types from "./types";
+import axios from 'axios';
+import * as types from './types';
 
-const API_PATH = "https://slohacks-backend-api.herokuapp.com";
+const API_PATH = 'https://slohacks-backend-api.herokuapp.com';
 
-export const signUp = (values, callback) => dispatch => {
+export const signUp = (values, callback) => (dispatch) => {
   dispatch({ type: types.SIGN_UP_ATTEMPT });
   axios
     .post(`${API_PATH}/users/signup`, {
       email: values.email,
-      password: values.password
+      password: values.password,
     })
-    .then(response => {
+    .then((response) => {
       const userCredential = response.data;
       dispatch({ type: types.SIGN_UP_GUCCI, userCredential });
       callback();
     })
-    .catch(error => {
+    .catch((error) => {
       const { errorMessage } = error.response.data;
       dispatch({ type: types.SIGN_UP_FAIL, errorMessage });
     });
 };
 
-export const login = values => dispatch => {
+export const login = values => (dispatch) => {
   dispatch({ type: types.LOGIN_ATTEMPT });
   axios
     .post(`${API_PATH}/users/login`, {
       email: values.email,
-      password: values.password
+      password: values.password,
     })
-    .then(response => {
+    .then((response) => {
       const userCredential = response.data;
       dispatch({ type: types.LOGIN_GUCCI, userCredential });
     })
-    .catch(error => {
+    .catch((error) => {
       const { errorMessage } = error.response.data;
       dispatch({ type: types.LOGIN_FAIL, errorMessage });
     });
 };
 
-export const rsvpResponse = () => dispatch => {
-    dispatch({ type: types.UPDATE_RSVP, rsvpVal: true });
+export const rsvpResponse = () => (dispatch) => {
+  dispatch({ type: types.UPDATE_RSVP, rsvpVal: true });
 };
 
-export const forgotPassword = values => dispatch => {
+export const forgotPassword = values => (dispatch) => {
   dispatch({ type: types.FORGOT_PASS_ATTEMPT });
   axios
     .post(`${API_PATH}/forgot-password/request`, {
-      email: values.email
+      email: values.email,
     })
-    .then(response => {
+    .then((response) => {
       const { success } = response.data;
       if (success === true) {
         dispatch({ type: types.FORGOT_PASS_GUCCI });
       }
     })
-    .catch(error => {
+    .catch((error) => {
       const { errorMessage } = error.response.data;
       dispatch({ type: types.FORGOT_PASS_FAIL, errorMessage });
     });
 };
 
-export const signout = () => dispatch => {
+export const signout = () => (dispatch) => {
   dispatch({ type: types.SIGN_OUT_GUCCI });
 };
 
 export function submitResponse(formProps) {
   return {
     type: types.SAVE_RESPONSE,
-    payload: formProps
+    payload: formProps,
   };
 }
 
-export const uploadResume = (user, resume, onChange) => dispatch => {
+export const uploadResume = (user, resume, onChange) => (dispatch) => {
   dispatch({ type: types.UPLOAD_RESUME_ATTEMPT });
   const data = new FormData();
-  data.append("resume", resume);
+  data.append('resume', resume);
 
   axios
     .post(`${API_PATH}/resumes`, data, {
       headers: {
-        Authorization: user.token
-      }
+        Authorization: user.token,
+      },
     })
     .then(() => {
       dispatch({ type: types.UPLOAD_RESUME_GUCCI, resume });
       onChange(resume.name);
     })
-    .catch(error => {
+    .catch((error) => {
       const { errorMessage } = error.response.data;
       dispatch({
         type: types.UPLOAD_RESUME_FAIL,
-        error: errorMessage
+        error: errorMessage,
       });
     });
 };
 
 export const clearResume = () => {
   return {
-    type: types.CLEAR_RESUME_ERROR
+    type: types.CLEAR_RESUME_ERROR,
   };
 };
 
-export const submitApp = (user, form) => dispatch => {
+export const submitApp = (user, form) => (dispatch) => {
   const formCopy = form;
   dispatch({ type: types.ATTEMPT_SUBMISSION });
   axios
     .post(`${API_PATH}/applications`, formCopy, {
       headers: {
-        Authorization: user.token
-      }
+        Authorization: user.token,
+      },
     })
-    .then(response => {
+    .then((response) => {
       dispatch({
         type: types.UPDATE_APPLICATION_TRUE,
         app: response.data,
-        rsvpInv: false
+        rsvpInv: false,
       });
       dispatch({ type: types.SUBMISSION_GUCCI });
     })
-    .catch(error => {
+    .catch((error) => {
       const { errorMessage } = error.response.data;
       dispatch({
         type: types.SUBMISSION_FAIL,
-        error: errorMessage
+        error: errorMessage,
       });
     });
 };

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -1,161 +1,128 @@
-import axios from 'axios';
-import * as types from './types';
-// import {
-//   firebase,
-//   applicationsRef,
-//   rsvpRef,
-// } from '../config/firebase';
+import axios from "axios";
+import * as types from "./types";
 
-const API_PATH = 'https://slohacks-backend-api.herokuapp.com';
+const API_PATH = "https://slohacks-backend-api.herokuapp.com";
 
-export const signUp = (values, callback) => (dispatch) => {
+export const signUp = (values, callback) => dispatch => {
   dispatch({ type: types.SIGN_UP_ATTEMPT });
   axios
     .post(`${API_PATH}/users/signup`, {
       email: values.email,
-      password: values.password,
+      password: values.password
     })
-    .then((response) => {
+    .then(response => {
       const userCredential = response.data;
       dispatch({ type: types.SIGN_UP_GUCCI, userCredential });
       callback();
     })
-    .catch((error) => {
+    .catch(error => {
       const { errorMessage } = error.response.data;
       dispatch({ type: types.SIGN_UP_FAIL, errorMessage });
     });
 };
 
-export const login = values => (dispatch) => {
+export const login = values => dispatch => {
   dispatch({ type: types.LOGIN_ATTEMPT });
   axios
     .post(`${API_PATH}/users/login`, {
       email: values.email,
-      password: values.password,
+      password: values.password
     })
-    .then((response) => {
+    .then(response => {
       const userCredential = response.data;
       dispatch({ type: types.LOGIN_GUCCI, userCredential });
     })
-    .catch((error) => {
+    .catch(error => {
       const { errorMessage } = error.response.data;
       dispatch({ type: types.LOGIN_FAIL, errorMessage });
     });
 };
 
-export const rsvpResponse = (user, form, push) => (dispatch) => {
-  // rsvpRef
-  //   .doc(user.uid)
-  //   .set(form)
-  //   .then(() => {
-  //     dispatch({ type: types.UPDATE_RSVP, rsvpVal: true });
-  //     push('/dashboard');
-  //   });
+export const rsvpResponse = () => dispatch => {
+    dispatch({ type: types.UPDATE_RSVP, rsvpVal: true });
 };
 
-export const forgotPassword = (values, callback) => (dispatch) => {
+export const forgotPassword = values => dispatch => {
   dispatch({ type: types.FORGOT_PASS_ATTEMPT });
-  // firebase
-  //   .auth()
-  //   .sendPasswordResetEmail(values.email)
-  //   .then((userCredential) => {
-  //     dispatch({ type: types.FORGOT_PASS_GUCCI, userCredential });
-  //     callback();
-  //   })
-  //   .catch((error) => {
-  //     dispatch({ type: types.FORGOT_PASS_FAIL, error });
-  //   });
+  axios
+    .post(`${API_PATH}/forgot-password/request`, {
+      email: values.email
+    })
+    .then(response => {
+      const { success } = response.data;
+      if (success === true) {
+        dispatch({ type: types.FORGOT_PASS_GUCCI });
+      }
+    })
+    .catch(error => {
+      const { errorMessage } = error.response.data;
+      dispatch({ type: types.FORGOT_PASS_FAIL, errorMessage });
+    });
 };
 
-export const signout = () => (dispatch) => {
+export const signout = () => dispatch => {
   dispatch({ type: types.SIGN_OUT_GUCCI });
 };
 
 export function submitResponse(formProps) {
   return {
     type: types.SAVE_RESPONSE,
-    payload: formProps,
+    payload: formProps
   };
 }
 
-export const uploadResume = (user, resume, onChange) => (dispatch) => {
+export const uploadResume = (user, resume, onChange) => dispatch => {
   dispatch({ type: types.UPLOAD_RESUME_ATTEMPT });
   const data = new FormData();
-  data.append('resume', resume);
+  data.append("resume", resume);
 
   axios
     .post(`${API_PATH}/resumes`, data, {
       headers: {
-        Authorization: user.token,
-      },
+        Authorization: user.token
+      }
     })
     .then(() => {
       dispatch({ type: types.UPLOAD_RESUME_GUCCI, resume });
       onChange(resume.name);
     })
-    .catch((error) => {
+    .catch(error => {
       const { errorMessage } = error.response.data;
       dispatch({
         type: types.UPLOAD_RESUME_FAIL,
-        error: errorMessage,
+        error: errorMessage
       });
     });
 };
 
 export const clearResume = () => {
   return {
-    type: types.CLEAR_RESUME_ERROR,
+    type: types.CLEAR_RESUME_ERROR
   };
 };
 
-export const submitApp = (user, form) => (dispatch) => {
+export const submitApp = (user, form) => dispatch => {
   const formCopy = form;
   dispatch({ type: types.ATTEMPT_SUBMISSION });
-  // const newForm = {
-  //   ...form,
-  //   time: firebase.firestore.Timestamp.now(),
-  //   email: firebase.auth().currentUser.email,
-  // };
-  // applicationsRef
-  //   .doc(user.uid)
-  //   .set(newForm)
-  //   .then(() => {
-  //     applicationsRef
-  //       .doc(user.uid)
-  //       .get()
-  //       .then((doc) => {
-  //         dispatch({
-  //           type: types.UPDATE_APPLICATION_TRUE,
-  //           app: doc.data(),
-  //           rsvpInv: false,
-  //         });
-  //       });
-  //     dispatch({ type: types.SUBMISSION_GUCCI });
-  //   })
-  //   .catch((error) => {
-  //     dispatch({ type: types.SUBMISSION_FAIL, error });
-  //   });
-  formCopy.grad_date = form.grad_date.replace('-', '');
-
   axios
     .post(`${API_PATH}/applications`, formCopy, {
       headers: {
-        Authorization: user.token,
-      },
+        Authorization: user.token
+      }
     })
-    .then((response) => {
+    .then(response => {
       dispatch({
         type: types.UPDATE_APPLICATION_TRUE,
         app: response.data,
-        rsvpInv: false,
+        rsvpInv: false
       });
       dispatch({ type: types.SUBMISSION_GUCCI });
     })
-    .catch((error) => {
+    .catch(error => {
       const { errorMessage } = error.response.data;
       dispatch({
         type: types.SUBMISSION_FAIL,
-        error: errorMessage,
+        error: errorMessage
       });
     });
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -4199,10 +4199,10 @@ eslint@^6.1.0:
     text-table "^0.2.0"
     v8-compile-cache "^2.0.3"
 
-eslint@^6.3.0:
-  version "6.4.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-6.4.0.tgz#5aa9227c3fbe921982b2eda94ba0d7fae858611a"
-  integrity sha512-WTVEzK3lSFoXUovDHEbkJqCVPEPwbhCq4trDktNI6ygs7aO41d4cDT0JFAT5MivzZeVLWlg7vHL+bgrQv/t3vA==
+eslint@^6.5.1:
+  version "6.5.1"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-6.5.1.tgz#828e4c469697d43bb586144be152198b91e96ed6"
+  integrity sha512-32h99BoLYStT1iq1v2P9uwpyznQ4M2jRiFB6acitKz52Gqn+vPaMDUTB1bYi1WN4Nquj2w+t+bimYUG83DC55A==
   dependencies:
     "@babel/code-frame" "^7.0.0"
     ajv "^6.10.0"


### PR DESCRIPTION
Rewrite the "forgot password" Redux action to make an HTTP POST request to the new MongoDB backend, replacing the old Firebase call.

(Also, properly add the `eslint` package for linting)